### PR TITLE
출시 전 코드 정리 및 버그 수정 

### DIFF
--- a/BookChat/app/build.gradle.kts
+++ b/BookChat/app/build.gradle.kts
@@ -20,17 +20,14 @@ android {
 
 dependencies {
 	implementation(libs.bundles.androidx.default)
-	// WorkManager
 	implementation(libs.bundles.workmanager)
 	implementation(project(":core:stomp:chatting:external"))
 	implementation(project(":core:util"))
 	implementation(project(":core:network-manager:external"))
 	implementation(project(":core:chat-client"))
-	ksp(libs.androidx.hilt.compiler)
 
-	//splash는 default Activity라서 지우면 안됨
+	/** 아래 feature 지우면 Navigation 에러남 */
 	implementation(project(":feature:splash"))
-	//아래 feature 지우면 Navigation 에러남
 	implementation(project(":feature:agony"))
 	implementation(project(":feature:bookreport"))
 	implementation(project(":feature:channel"))

--- a/BookChat/buildSrc/src/main/kotlin/convention.android.application.gradle.kts
+++ b/BookChat/buildSrc/src/main/kotlin/convention.android.application.gradle.kts
@@ -1,4 +1,5 @@
 import gradle.configure.configureKotlinAndroid
+import gradle.configure.libs
 
 plugins {
 	id("com.android.application")
@@ -7,7 +8,7 @@ plugins {
 
 android {
 	configureKotlinAndroid(this)
-	defaultConfig.targetSdk = 34
+	defaultConfig.targetSdk = libs.findVersion("targetSdk").get().requiredVersion.toInt()
 
 	buildTypes {
 		release {

--- a/BookChat/buildSrc/src/main/kotlin/convention.android.library.gradle.kts
+++ b/BookChat/buildSrc/src/main/kotlin/convention.android.library.gradle.kts
@@ -1,4 +1,5 @@
 import gradle.configure.configureKotlinAndroid
+import gradle.configure.libs
 
 plugins {
 	id("com.android.library")
@@ -7,7 +8,7 @@ plugins {
 
 android {
 	configureKotlinAndroid(this)
-
+	defaultConfig.targetSdk = libs.findVersion("targetSdk").get().requiredVersion.toInt()
 	defaultConfig {
 		consumerProguardFiles("proguard-rules.pro")
 	}

--- a/BookChat/core/chat-client/src/main/kotlin/com/kova700/bookchat/core/chatclient/ChatClientImpl.kt
+++ b/BookChat/core/chat-client/src/main/kotlin/com/kova700/bookchat/core/chatclient/ChatClientImpl.kt
@@ -1,7 +1,6 @@
 package com.kova700.bookchat.core.chatclient
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.LifecycleOwner
 import com.kova700.bookchat.core.chat_client.R
 import com.kova700.bookchat.core.data.channel.external.repository.ChannelRepository
@@ -15,7 +14,6 @@ import com.kova700.bookchat.core.stomp.chatting.external.model.ChannelSubscripti
 import com.kova700.bookchat.core.stomp.chatting.external.model.SocketConnectionFailureException
 import com.kova700.bookchat.core.stomp.chatting.external.model.SocketState
 import com.kova700.bookchat.core.stomp.chatting.external.model.SubscriptionState
-import com.kova700.bookchat.util.Constants.TAG
 import com.kova700.bookchat.util.toast.makeToast
 import com.kova700.core.domain.usecase.client.LogoutUseCase
 import com.kova700.core.domain.usecase.client.WithdrawUseCase
@@ -167,7 +165,6 @@ class ChatClientImpl @Inject constructor(
 	}
 
 	private fun disconnectSocket() = chatClientScope.launch {
-		Log.d(TAG, "ChatClientImpl: disconnectSocket() - called")
 		stompHandler.disconnectSocket()
 	}
 

--- a/BookChat/core/data/channel/internal/src/main/kotlin/com/kova700/bookchat/core/data/channel/internal/ChannelRepositoryImpl.kt
+++ b/BookChat/core/data/channel/internal/src/main/kotlin/com/kova700/bookchat/core/data/channel/internal/ChannelRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.kova700.bookchat.core.data.channel.internal
 
-import android.util.Log
 import com.kova700.bookchat.core.data.channel.external.model.Channel
 import com.kova700.bookchat.core.data.channel.external.model.ChannelDefaultImageType
 import com.kova700.bookchat.core.data.channel.external.model.ChannelInfo
@@ -26,7 +25,6 @@ import com.kova700.bookchat.core.network.bookchat.channel.model.request.RequestM
 import com.kova700.bookchat.core.network.bookchat.channel.model.response.BookChatFailResponseBody
 import com.kova700.bookchat.core.network.bookchat.common.mapper.toBookRequest
 import com.kova700.bookchat.core.network.util.multipart.toMultiPartBody
-import com.kova700.bookchat.util.Constants.TAG
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -95,7 +93,6 @@ class ChannelRepositoryImpl @Inject constructor(
 	 * + 해당 채팅방에 입장하지 않은 채로 해당 API 호출하면 예외 던짐
 	 * {"errorCode":"4040400","message":"채팅방을 찾을 수 없습니다."}*/
 	private suspend fun getOnlineChannel(channelId: Long): Channel? {
-		Log.d(TAG, "ChannelRepositoryImpl: getOnlineChannel() - called")
 		val channel = when (val response = channelApi.getChannel(channelId)) {
 			is BookChatApiResult.Success -> response.data.toChannel()
 
@@ -123,7 +120,6 @@ class ChannelRepositoryImpl @Inject constructor(
 		maxAttempts: Int,
 	): ChannelInfo? {
 		for (attempt in 0 until maxAttempts) {
-			Log.d(TAG, "ChannelRepositoryImpl: getChannelInfo() - attempt :$attempt")
 			val response = runCatching { channelApi.getChannelInfo(channelId) }
 				.onFailure { delay((DEFAULT_RETRY_ATTEMPT_DELAY_TIME * (1.5).pow(attempt))) }
 				.getOrNull() ?: continue

--- a/BookChat/core/domain/src/main/kotlin/com/kova700/core/domain/usecase/chat/GetChannelChatsFlowUseCase.kt
+++ b/BookChat/core/domain/src/main/kotlin/com/kova700/core/domain/usecase/chat/GetChannelChatsFlowUseCase.kt
@@ -1,6 +1,5 @@
 package com.kova700.core.domain.usecase.chat
 
-import android.util.Log
 import com.kova700.bookchat.core.data.channel.external.repository.ChannelRepository
 import com.kova700.bookchat.core.data.chat.external.model.Chat
 import com.kova700.bookchat.core.data.chat.external.model.ChatState
@@ -27,7 +26,6 @@ class GetChannelChatsFlowUseCase @Inject constructor(
 			channelId = channelId
 		).map { chats -> chats.map { it.attachUser() } }
 			.onEach { chats ->
-				Log.d("ㄺ", "GetChatsFlowUseCase: invoke(channelId : $channelId) - chats :$chats")
 				val newestChatInList =
 					chats.firstOrNull { chat -> chat.state == ChatState.SUCCESS }
 				newestChatInList?.let { chat ->

--- a/BookChat/core/fcm/chat/src/main/kotlin/com/kova700/bookchat/core/fcm/chat/ChatNotificationWorker.kt
+++ b/BookChat/core/fcm/chat/src/main/kotlin/com/kova700/bookchat/core/fcm/chat/ChatNotificationWorker.kt
@@ -1,7 +1,6 @@
 package com.kova700.bookchat.core.fcm.chat
 
 import android.content.Context
-import android.util.Log
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
@@ -32,7 +31,6 @@ class ChatNotificationWorker @AssistedInject constructor(
 ) : CoroutineWorker(appContext, workerParams) {
 
 	override suspend fun doWork(): Result {
-		Log.d("ㄺ", "ChatNotificationWorker: doWork() - just called")
 		if (bookChatTokenRepository.isBookChatTokenExist().not()) return Result.success()
 		val channelId: Long = inputData.getLong(EXTRA_CHANNEL_ID, -1)
 		val chatId: Long = inputData.getLong(EXTRA_CHAT_ID, -1)
@@ -45,7 +43,6 @@ class ChatNotificationWorker @AssistedInject constructor(
 		val apiResult = runCatching {
 			val channel = getClientChannelUseCase(channelId) ?: return Result.failure()
 			val chat = getChatUseCase(chatId) ?: return Result.failure()
-			Log.d("ㄺ", "ChatNotificationWorker: doWork() - real Work")
 			channelRepository.updateChannelLastChatIfValid(chat.channelId, chat)
 			Pair(channel, chat)
 		}.getOrNull() ?: return Result.failure()

--- a/BookChat/core/fcm/chat/src/main/kotlin/com/kova700/bookchat/core/fcm/chat/ChatNotificationWorker.kt
+++ b/BookChat/core/fcm/chat/src/main/kotlin/com/kova700/bookchat/core/fcm/chat/ChatNotificationWorker.kt
@@ -19,7 +19,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
 //TODO : [Version 2] 구독(온라인) 상태임에도 FCM이 수신되는 현상이 있음 + 본인이 보낸 메세지임에도 FCM이 수신되는 상황
-//TODO : [FixWaiting] SenderId를 함께 넘겨 받아서 만약 Sender가 클라이언트라면 아래 API호출하지 않게 수정
 @HiltWorker
 class ChatNotificationWorker @AssistedInject constructor(
 	@Assisted private val appContext: Context,
@@ -37,17 +36,21 @@ class ChatNotificationWorker @AssistedInject constructor(
 		if (bookChatTokenRepository.isBookChatTokenExist().not()) return Result.success()
 		val channelId: Long = inputData.getLong(EXTRA_CHANNEL_ID, -1)
 		val chatId: Long = inputData.getLong(EXTRA_CHAT_ID, -1)
+		val senderId: Long = inputData.getLong(EXTRA_SENDER_ID, -1)
+
+		val client = runCatching { clientRepository.getClientProfile() }
+			.getOrNull() ?: return Result.failure()
+		if (senderId == client.id) return Result.success()
 
 		val apiResult = runCatching {
 			val channel = getClientChannelUseCase(channelId) ?: return Result.failure()
 			val chat = getChatUseCase(chatId) ?: return Result.failure()
-			val client = clientRepository.getClientProfile() //TODO : [FixWaiting] 이거도 로그인 데이터 없으면 서버 호출하겠네
 			Log.d("ㄺ", "ChatNotificationWorker: doWork() - real Work")
 			channelRepository.updateChannelLastChatIfValid(chat.channelId, chat)
-			Triple(channel, chat, client)
+			Pair(channel, chat)
 		}.getOrNull() ?: return Result.failure()
 
-		val (channel, chat, client) = apiResult
+		val (channel, chat) = apiResult
 		if (chat.sender?.id == client.id) return Result.success()
 
 		chatNotificationHandler.showNotification(
@@ -61,17 +64,20 @@ class ChatNotificationWorker @AssistedInject constructor(
 	companion object {
 		private const val EXTRA_CHANNEL_ID = "EXTRA_CHANNEL_ID"
 		private const val EXTRA_CHAT_ID = "EXTRA_CHAT_ID"
+		private const val EXTRA_SENDER_ID = "EXTRA_SENDER_ID"
 
 		fun start(
 			context: Context,
 			channelId: Long,
 			chatId: Long,
+			senderId: Long
 		) {
 			val loadChatDataWork = OneTimeWorkRequestBuilder<ChatNotificationWorker>()
 				.setInputData(
 					workDataOf(
 						EXTRA_CHANNEL_ID to channelId,
-						EXTRA_CHAT_ID to chatId
+						EXTRA_CHAT_ID to chatId,
+						EXTRA_SENDER_ID to senderId
 					)
 				).build()
 

--- a/BookChat/core/fcm/forced-logout/src/main/kotlin/com/kova700/bookchat/core/fcm/forced_logout/ForcedLogoutManagerImpl.kt
+++ b/BookChat/core/fcm/forced-logout/src/main/kotlin/com/kova700/bookchat/core/fcm/forced_logout/ForcedLogoutManagerImpl.kt
@@ -11,7 +11,6 @@ import com.kova700.bookchat.feature.login.LoginActivity
 import com.kova700.core.domain.usecase.client.LogoutUseCase
 import javax.inject.Inject
 
-//TODO : [FixWaiting] 같은 기기로 재로그인 시에, 같은 기기가 로그아웃 FCM을 받는현상 발생
 class ForcedLogoutManagerImpl @Inject constructor(
 	private val logoutUseCase: LogoutUseCase,
 ) : ForcedLogoutManager {

--- a/BookChat/core/fcm/renew-fcm-token/src/main/kotlin/com/kova700/bookchat/core/fcm/renew_fcm_token/RenewFcmTokenWorker.kt
+++ b/BookChat/core/fcm/renew-fcm-token/src/main/kotlin/com/kova700/bookchat/core/fcm/renew_fcm_token/RenewFcmTokenWorker.kt
@@ -26,9 +26,9 @@ class RenewFcmTokenWorker @AssistedInject constructor(
 		if (bookChatTokenRepository.isBookChatTokenExist().not()) return Result.success()
 
 		val fcmTokenString: String = inputData.getString(EXTRA_FCM_TOKEN) ?: return Result.failure()
-		return runCatching { fcmTokenRepository.renewFCMToken(FCMToken(fcmTokenString)) }
-			.map { Result.success() }
-			.getOrElse { return Result.failure() }
+		runCatching { fcmTokenRepository.renewFCMToken(FCMToken(fcmTokenString)) }
+			.getOrNull() ?: return Result.failure()
+		return Result.success()
 	}
 
 	companion object {

--- a/BookChat/core/fcm/service/src/main/kotlin/com/kova700/bookchat/core/fcm/service/FCMService.kt
+++ b/BookChat/core/fcm/service/src/main/kotlin/com/kova700/bookchat/core/fcm/service/FCMService.kt
@@ -1,6 +1,5 @@
 package com.kova700.bookchat.core.fcm.service
 
-import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.kova700.bookchat.core.fcm.chat.ChatNotificationWorker
@@ -10,7 +9,6 @@ import com.kova700.bookchat.core.fcm.renew_fcm_token.RenewFcmTokenWorker
 import com.kova700.bookchat.core.fcm.service.model.ChatFcmBody
 import com.kova700.bookchat.core.fcm.service.model.FcmMessage
 import com.kova700.bookchat.core.fcm.service.model.PushType
-import com.kova700.bookchat.util.Constants.TAG
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -34,7 +32,6 @@ class FCMService : FirebaseMessagingService() {
 	private fun handleMessage(message: RemoteMessage) {
 		val messageBody = message.data["body"] ?: return
 		val fcmMessage = jsonSerializer.decodeFromString<FcmMessage>(messageBody)
-		Log.d(TAG, "FCMService: handleMessage() - fcmMessage : $fcmMessage")
 		when (fcmMessage.pushType) {
 			PushType.LOGIN -> startForcedLogoutWorker()
 			PushType.CHAT -> handleChatMessage(fcmMessage)

--- a/BookChat/core/fcm/service/src/main/kotlin/com/kova700/bookchat/core/fcm/service/FCMService.kt
+++ b/BookChat/core/fcm/service/src/main/kotlin/com/kova700/bookchat/core/fcm/service/FCMService.kt
@@ -45,15 +45,21 @@ class FCMService : FirebaseMessagingService() {
 		if (fcmMessage.body !is ChatFcmBody) return
 		startChatNotificationWorker(
 			channelId = fcmMessage.body.channelId,
-			chatId = fcmMessage.body.chatId
+			chatId = fcmMessage.body.chatId,
+			senderId = fcmMessage.body.senderId
 		)
 	}
 
-	private fun startChatNotificationWorker(channelId: Long, chatId: Long) {
+	private fun startChatNotificationWorker(
+		channelId: Long,
+		chatId: Long,
+		senderId: Long
+	) {
 		ChatNotificationWorker.start(
 			context = applicationContext,
 			channelId = channelId,
-			chatId = chatId
+			chatId = chatId,
+			senderId = senderId
 		)
 	}
 

--- a/BookChat/core/fcm/service/src/main/kotlin/com/kova700/bookchat/core/fcm/service/model/FcmMessage.kt
+++ b/BookChat/core/fcm/service/src/main/kotlin/com/kova700/bookchat/core/fcm/service/model/FcmMessage.kt
@@ -36,8 +36,9 @@ data class ChatFcmBody(
 	val chatId: Long,
 	@SerialName("chatRoomId")
 	val channelId: Long,
+	@SerialName("senderId")
+	val senderId: Long,
 ) : FcmBody
-
 
 
 object FcmMessageSerializer : KSerializer<FcmMessage> {

--- a/BookChat/core/network/network/src/main/kotlin/com/kova700/bookchat/core/network/network/RetrofitModule.kt
+++ b/BookChat/core/network/network/src/main/kotlin/com/kova700/bookchat/core/network/network/RetrofitModule.kt
@@ -57,10 +57,10 @@ object RetrofitModule {
 	@Singleton
 	fun provideOkHttpClient(
 		interceptor: Interceptor,
-		httpLoggingInterceptor: HttpLoggingInterceptor,
+//		httpLoggingInterceptor: HttpLoggingInterceptor,
 	): OkHttpClient {
 		return OkHttpClient.Builder()
-			.addNetworkInterceptor(httpLoggingInterceptor) //TODO : [FixWaiting] 릴리즈 버전에서는 제거해야함
+//			.addNetworkInterceptor(httpLoggingInterceptor)
 			.addInterceptor(interceptor)
 			.build()
 	}

--- a/BookChat/core/remote-config/src/main/kotlin/com/kova700/bookchat/core/remoteconfig/RemoteConfigManager.kt
+++ b/BookChat/core/remote-config/src/main/kotlin/com/kova700/bookchat/core/remoteconfig/RemoteConfigManager.kt
@@ -1,6 +1,5 @@
 package com.kova700.bookchat.core.remoteconfig
 
-import android.util.Log
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.remoteconfig.ConfigUpdate
 import com.google.firebase.remoteconfig.ConfigUpdateListener
@@ -59,8 +58,6 @@ class RemoteConfigManager @Inject constructor() {
 		remoteConfig.addOnConfigUpdateListener(object : ConfigUpdateListener {
 			override fun onUpdate(configUpdate: ConfigUpdate) {
 				val updatedKeys = configUpdate.updatedKeys
-				Log.d("ㄺ", "RemoteConfigManager: onUpdate() - updatedKeys : $updatedKeys")
-
 				if (updatedKeys.contains(IS_SERVER_ENABLED_KEY)
 					|| updatedKeys.contains(IS_SERVER_UNDER_MAINTENANCE_KEY)
 					|| updatedKeys.contains(SERVER_DOWN_NOTICE_TEXT_KEY)

--- a/BookChat/core/stomp/chatting/external/src/main/kotlin/com/kova700/bookchat/core/stomp/chatting/external/model/SocketMessages.kt
+++ b/BookChat/core/stomp/chatting/external/src/main/kotlin/com/kova700/bookchat/core/stomp/chatting/external/model/SocketMessages.kt
@@ -3,11 +3,12 @@ package com.kova700.bookchat.core.stomp.chatting.external.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-// TODO : [Version 2] FCM 안오다가 채팅방 들어갔다 나오면 FCM 받아지는 현상이 있음
-//  아마 서버에서 disconnected 상태 업데이트가 아직 안되어서 FCM 수신이 안되는 듯하다
-//  추후 앱 단위에서 소켓 연결하고 모든 소켓 Frame에 ChannelId, ChatId를 포함하여
-//  모든 채팅방이 자동 subscribe된 채로 사용되는 형식으로 수정하해야 할듯하다.
-//  connect 보내면 서버에서 subscribeAllChannels로 모든 채팅방을 subscribe되게도 가능하겠다.(어차피 모든 채팅방 구독해야하니까)
+// TODO : [Version 2] ChatId를 Long타입이 아닌 String타입으로 클라이언트에서 "UUID-UserID" 형식으로
+//      서버로 전송하는 구조를 사용하면 receiptId를 굳이 사용하지 않아도 되게 수정이 가능해보임
+//      (하지만 쿼리 속도가 좀 느려지는 단점이 존재하긴 함)
+//      현재 구조에서 메세지의 전송은 완료되었는데 소켓 끊김으로 해당 채팅을 수신하지 않으면
+//      해당 채팅의 receiptId에 해당하는 전송 대기 채팅이 전송 완료 상태로 수정되지 않기 때문에
+//      같은 채팅에 대한 중복 생성이 발생할 가능성이 있음
 
 sealed interface SocketMessage
 

--- a/BookChat/core/stomp/chatting/internal/src/main/kotlin/com/kova700/bookchat/core/stomp/chatting/internal/SocketMessageHandlerImpl.kt
+++ b/BookChat/core/stomp/chatting/internal/src/main/kotlin/com/kova700/bookchat/core/stomp/chatting/internal/SocketMessageHandlerImpl.kt
@@ -1,6 +1,5 @@
 package com.kova700.bookchat.core.stomp.chatting.internal
 
-import android.util.Log
 import com.kova700.bookchat.core.data.channel.external.model.ChannelMemberAuthority
 import com.kova700.bookchat.core.data.channel.external.repository.ChannelRepository
 import com.kova700.bookchat.core.data.chat.external.model.Chat
@@ -14,7 +13,6 @@ import com.kova700.bookchat.core.stomp.chatting.external.model.NotificationMessa
 import com.kova700.bookchat.core.stomp.chatting.external.model.NotificationMessageType
 import com.kova700.bookchat.core.stomp.chatting.external.model.SocketMessage
 import com.kova700.bookchat.core.stomp.chatting.internal.mapper.toChat
-import com.kova700.bookchat.util.Constants.TAG
 import com.kova700.core.domain.usecase.channel.GetClientChannelUseCase
 import javax.inject.Inject
 
@@ -131,7 +129,6 @@ class SocketMessageHandlerImpl @Inject constructor(
 	}
 
 	private suspend fun updateWaitingChat(chat: Chat, receiptId: Long) {
-		Log.d(TAG, "SocketMessageHandlerImpl: updateWaitingChat() - receiptId :$receiptId")
 		chatRepository.updateWaitingChat(
 			newChat = chat,
 			receiptId = receiptId

--- a/BookChat/core/stomp/stomp/src/main/kotlin/com/kova700/bookchat/core/stomp/stomp/StompClientModule.kt
+++ b/BookChat/core/stomp/stomp/src/main/kotlin/com/kova700/bookchat/core/stomp/stomp/StompClientModule.kt
@@ -1,6 +1,5 @@
 package com.kova700.bookchat.core.stomp.stomp
 
-import android.util.Log
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -9,10 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
 import org.hildan.krossbow.stomp.StompClient
 import org.hildan.krossbow.stomp.config.HeartBeat
-import org.hildan.krossbow.stomp.frame.StompFrame
-import org.hildan.krossbow.stomp.instrumentation.KrossbowInstrumentation
 import org.hildan.krossbow.websocket.WebSocketClient
-import org.hildan.krossbow.websocket.WebSocketFrame
 import org.hildan.krossbow.websocket.okhttp.OkHttpWebSocketClient
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.seconds
@@ -46,39 +42,33 @@ object StompClientModule {
 					expectedPeriod = 10.seconds
 				)
 				defaultSessionCoroutineContext = Dispatchers.IO
-				instrumentation = debugInstrumentation
+//				instrumentation = debugInstrumentation
 			})
 	}
 
-	private val debugInstrumentation = object : KrossbowInstrumentation {
-		val TAG = "Stomp"
-		override suspend fun onWebSocketFrameReceived(frame: WebSocketFrame) {
-			super.onWebSocketFrameReceived(frame)
-			Log.d(TAG, "StompModule: onWebSocketFrameReceived() - frame : $frame")
-		}
-
-		override suspend fun onWebSocketClosed(cause: Throwable?) {
-			super.onWebSocketClosed(cause)
-			Log.d(TAG, "StompModule: onWebSocketClosed() - cause : $cause")
-		}
-
-		override suspend fun onWebSocketClientError(exception: Throwable) {
-			super.onWebSocketClientError(exception)
-			Log.d(TAG, "StompModule: onWebSocketClientError() - exception : $exception")
-		}
-
-		override suspend fun onStompFrameSent(frame: StompFrame) {
-			super.onStompFrameSent(frame)
-			Log.d(TAG, "StompModule: onStompFrameSent() - frame : $frame")
-		}
-
-		override suspend fun onFrameDecoded(
-			originalFrame: WebSocketFrame,
-			decodedFrame: StompFrame,
-		) {
-			super.onFrameDecoded(originalFrame, decodedFrame)
-			Log.d(TAG, "StompModule: onFrameDecoded() - originalFrame : $originalFrame")
-			Log.d(TAG, "StompModule: onFrameDecoded() - decodedFrame : $decodedFrame")
-		}
-	}
+//	private val debugInstrumentation = object : KrossbowInstrumentation {
+//		val TAG = "Stomp"
+//		override suspend fun onWebSocketFrameReceived(frame: WebSocketFrame) {
+//			super.onWebSocketFrameReceived(frame)
+//		}
+//
+//		override suspend fun onWebSocketClosed(cause: Throwable?) {
+//			super.onWebSocketClosed(cause)
+//		}
+//
+//		override suspend fun onWebSocketClientError(exception: Throwable) {
+//			super.onWebSocketClientError(exception)
+//		}
+//
+//		override suspend fun onStompFrameSent(frame: StompFrame) {
+//			super.onStompFrameSent(frame)
+//		}
+//
+//		override suspend fun onFrameDecoded(
+//			originalFrame: WebSocketFrame,
+//			decodedFrame: StompFrame,
+//		) {
+//			super.onFrameDecoded(originalFrame, decodedFrame)
+//		}
+//	}
 }

--- a/BookChat/core/util/build.gradle.kts
+++ b/BookChat/core/util/build.gradle.kts
@@ -9,10 +9,7 @@ android {
 
 dependencies {
 	implementation(libs.bundles.androidx.default)
-	// Glide
-	implementation(libs.glide)
-	ksp(libs.glide.compiler)
-
+	implementation(libs.bundles.coil)
 	implementation(project(":core:design-system"))
 	implementation(project(":core:data:user:external"))
 	implementation(project(":core:data:channel:external"))

--- a/BookChat/core/util/build.gradle.kts
+++ b/BookChat/core/util/build.gradle.kts
@@ -9,7 +9,8 @@ android {
 
 dependencies {
 	implementation(libs.bundles.androidx.default)
-	implementation(libs.bundles.coil)
+	implementation(libs.glide)
+	ksp(libs.glide.compiler)
 	implementation(project(":core:design-system"))
 	implementation(project(":core:data:user:external"))
 	implementation(project(":core:data:channel:external"))

--- a/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/emoji/EmojiUtil.kt
+++ b/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/emoji/EmojiUtil.kt
@@ -2,14 +2,28 @@ package com.kova700.bookchat.util.emoji
 
 import android.icu.text.BreakIterator
 
-fun String.isSingleTextOrEmoji(): Boolean {
+fun String.isSingleEmoji(): Boolean {
 	val boundary = BreakIterator.getCharacterInstance().apply {
-		setText(this@isSingleTextOrEmoji)
+		setText(this@isSingleEmoji)
 	}
 	var count = 0
 	while (boundary.next() != BreakIterator.DONE) {
 		count++
 		if (count > 1) return false
 	}
-	return true
+	return isEmoji()
 }
+
+fun String.isEmoji(): Boolean = matches(
+	("(?:[\uD83C\uDF00-\uD83D\uDDFF]|[\uD83E\uDD00-\uD83E\uDDFF]|" +
+					"[\uD83D\uDE00-\uD83D\uDE4F]|[\uD83D\uDE80-\uD83D\uDEFF]|" +
+					"[\u2600-\u26FF]\uFE0F?|[\u2700-\u27BF]\uFE0F?|\u24C2\uFE0F?|" +
+					"[\uD83C\uDDE6-\uD83C\uDDFF]{1,2}|" +
+					"[\uD83C\uDD70\uD83C\uDD71\uD83C\uDD7E\uD83C\uDD7F\uD83C\uDD8E\uD83C\uDD91-\uD83C\uDD9A]\uFE0F?|" +
+					"[\u0023\u002A\u0030-\u0039]\uFE0F?\u20E3|[\u2194-\u2199\u21A9-\u21AA]\uFE0F?|[\u2B05-\u2B07\u2B1B\u2B1C\u2B50\u2B55]\uFE0F?|" +
+					"[\u2934\u2935]\uFE0F?|[\u3030\u303D]\uFE0F?|[\u3297\u3299]\uFE0F?|" +
+					"[\uD83C\uDE01\uD83C\uDE02\uD83C\uDE1A\uD83C\uDE2F\uD83C\uDE32-\uD83C\uDE3A\uD83C\uDE50\uD83C\uDE51]\uFE0F?|" +
+					"[\u203C\u2049]\uFE0F?|[\u25AA\u25AB\u25B6\u25C0\u25FB-\u25FE]\uFE0F?|" +
+					"[\u00A9\u00AE]\uFE0F?|[\u2122\u2139]\uFE0F?|\uD83C\uDC04\uFE0F?|\uD83C\uDCCF\uFE0F?|" +
+					"[\u231A\u231B\u2328\u23CF\u23E9-\u23F3\u23F8-\u23FA]\uFE0F?)+").toRegex()
+)

--- a/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/image/bitmap/BitmapConverter.kt
+++ b/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/image/bitmap/BitmapConverter.kt
@@ -14,9 +14,9 @@ import android.graphics.Rect
 import android.graphics.RectF
 import android.os.Build
 import androidx.annotation.DrawableRes
-import coil3.imageLoader
-import coil3.request.ImageRequest
-import coil3.toBitmap
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.drawable.toBitmap
+import com.bumptech.glide.Glide
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -65,11 +65,14 @@ suspend fun @receiver:DrawableRes Int.getImageBitmap(
 	context: Context,
 ): Bitmap {
 	return withContext(Dispatchers.IO) {
-		context.imageLoader.execute(
-			ImageRequest.Builder(context)
-				.data(this@getImageBitmap)
-				.build()
-		).image?.toBitmap()!!
+		Glide.with(context)
+			.asBitmap()
+			.load(
+				AppCompatResources
+					.getDrawable(context, this@getImageBitmap)
+					?.toBitmap(config = Bitmap.Config.ARGB_8888)
+			).submit()
+			.get()
 	}
 }
 
@@ -79,11 +82,11 @@ suspend fun String.getImageBitmap(
 ): Bitmap? {
 	return withContext(Dispatchers.IO) {
 		runCatching {
-			context.imageLoader.execute(
-				ImageRequest.Builder(context)
-					.data(this@getImageBitmap)
-					.build()
-			).image?.toBitmap()
+			Glide.with(context)
+				.asBitmap()
+				.load(this@getImageBitmap)
+				.submit()
+				.get()
 		}.getOrNull()
 	}
 }

--- a/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/image/bitmap/BitmapConverter.kt
+++ b/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/image/bitmap/BitmapConverter.kt
@@ -14,9 +14,9 @@ import android.graphics.Rect
 import android.graphics.RectF
 import android.os.Build
 import androidx.annotation.DrawableRes
-import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.graphics.drawable.toBitmap
-import com.bumptech.glide.Glide
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.toBitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -65,14 +65,11 @@ suspend fun @receiver:DrawableRes Int.getImageBitmap(
 	context: Context,
 ): Bitmap {
 	return withContext(Dispatchers.IO) {
-		Glide.with(context)
-			.asBitmap()
-			.load(
-				AppCompatResources
-					.getDrawable(context, this@getImageBitmap)
-					?.toBitmap(config = Bitmap.Config.ARGB_8888)
-			).submit()
-			.get()
+		context.imageLoader.execute(
+			ImageRequest.Builder(context)
+				.data(this@getImageBitmap)
+				.build()
+		).image?.toBitmap()!!
 	}
 }
 
@@ -82,11 +79,11 @@ suspend fun String.getImageBitmap(
 ): Bitmap? {
 	return withContext(Dispatchers.IO) {
 		runCatching {
-			Glide.with(context)
-				.asBitmap()
-				.load(this@getImageBitmap)
-				.submit()
-				.get()
+			context.imageLoader.execute(
+				ImageRequest.Builder(context)
+					.data(this@getImageBitmap)
+					.build()
+			).image?.toBitmap()
 		}.getOrNull()
 	}
 }

--- a/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/image/bitmap/BitmapConverter.kt
+++ b/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/image/bitmap/BitmapConverter.kt
@@ -20,15 +20,33 @@ import java.io.ByteArrayOutputStream
 
 private const val BITMAP_COMPRESS_QUALITY_DEFAULT = 80
 
+//MAX_IMAGE_SIZE = 100KB
+private const val MAX_IMAGE_SIZE_BYTES = 100 * 1024
+
 suspend fun Bitmap.compressToByteArray(compressQuality: Int = BITMAP_COMPRESS_QUALITY_DEFAULT): ByteArray {
-	return withContext(Dispatchers.IO) {
+	fun compress(quality: Int): ByteArray {
 		val stream = ByteArrayOutputStream()
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-			compress(Bitmap.CompressFormat.WEBP_LOSSLESS, compressQuality, stream)
-			stream.toByteArray()
+		return when {
+			Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> {
+				compress(Bitmap.CompressFormat.WEBP_LOSSLESS, quality, stream)
+				stream.toByteArray()
+			}
+
+			else -> {
+				compress(Bitmap.CompressFormat.WEBP, quality, stream)
+				stream.toByteArray()
+			}
 		}
-		compress(Bitmap.CompressFormat.WEBP, BITMAP_COMPRESS_QUALITY_DEFAULT, stream)
-		stream.toByteArray()
+	}
+
+	return withContext(Dispatchers.IO) {
+		var quality = compressQuality
+		var byteArray = compress(quality)
+		quality -= 5
+		while (byteArray.size > MAX_IMAGE_SIZE_BYTES) {
+			byteArray = compress(quality)
+		}
+		byteArray
 	}
 }
 
@@ -68,7 +86,7 @@ suspend fun String.getImageBitmap(
 }
 
 /** 기본적으로 가로,세로 최대 길이를 제한하지 않고
- * 총 픽셀 수 ( 가로 x 세로 ) 가 최대 치 이상인 경우에만 제한
+ * 총 픽셀 수 (가로 x 세로) 가 최대 치 이상인 경우에만 제한
  * 이미지 축소를 할 때는 (가로 , 세로) 중 더 긴 길이를 기준으로 축소 */
 suspend fun Bitmap.scaleDownWithAspectRatio(
 	maxWidth: Int,

--- a/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/image/image/ImageLoadUtil.kt
+++ b/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/image/image/ImageLoadUtil.kt
@@ -2,7 +2,9 @@ package com.kova700.bookchat.util.image.image
 
 import android.graphics.Bitmap
 import android.widget.ImageView
-import com.bumptech.glide.Glide
+import coil3.load
+import coil3.request.error
+import coil3.request.placeholder
 import com.kova700.bookchat.core.data.channel.external.model.ChannelDefaultImageType
 import com.kova700.bookchat.core.data.user.external.model.UserDefaultProfileType
 import com.kova700.bookchat.core.design_system.R
@@ -19,11 +21,14 @@ fun ImageView.loadUrl(
 		return
 	}
 
-	Glide.with(context)
-		.load(url)
-		.placeholder(placeholderResId)
-		.error(errorResId)
-		.into(this)
+	val key = url
+	if (tag == key) return
+	tag = key
+
+	load(url) {
+		placeholder(placeholderResId)
+		error(errorResId)
+	}
 }
 
 fun ImageView.loadBitmap(
@@ -32,12 +37,14 @@ fun ImageView.loadBitmap(
 	errorResId: Int = R.drawable.error_img,
 ) {
 	if (bitmap == null) return
+	val key = bitmap.hashCode()
+	if (tag == key) return
+	tag = key
 
-	Glide.with(context)
-		.load(bitmap)
-		.placeholder(placeholderResId)
-		.error(errorResId)
-		.into(this)
+	load(bitmap) {
+		placeholder(placeholderResId)
+		error(errorResId)
+	}
 }
 
 fun ImageView.loadByteArray(
@@ -48,14 +55,12 @@ fun ImageView.loadByteArray(
 	if (byteArray == null || byteArray.isEmpty()) return
 	val key = byteArray.contentHashCode()
 	if (tag == key) return
-
 	tag = key
-	Glide.with(context)
-		.asBitmap()
-		.load(byteArray)
-		.placeholder(placeholderResId)
-		.error(errorResId)
-		.into(this)
+
+	load(byteArray) {
+		placeholder(placeholderResId)
+		error(errorResId)
+	}
 }
 
 fun ImageView.loadResId(
@@ -63,11 +68,14 @@ fun ImageView.loadResId(
 	placeholderResId: Int = R.drawable.loading_img,
 	errorResId: Int = R.drawable.error_img,
 ) {
-	Glide.with(context)
-		.load(resId)
-		.placeholder(placeholderResId)
-		.error(errorResId)
-		.into(this)
+	val key = resId
+	if (tag == key) return
+	tag = key
+
+	load(resId) {
+		placeholder(placeholderResId)
+		error(errorResId)
+	}
 }
 
 fun ImageView.loadUserProfile(

--- a/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/image/image/ImageLoadUtil.kt
+++ b/BookChat/core/util/src/main/kotlin/com/kova700/bookchat/util/image/image/ImageLoadUtil.kt
@@ -2,9 +2,8 @@ package com.kova700.bookchat.util.image.image
 
 import android.graphics.Bitmap
 import android.widget.ImageView
-import coil3.load
-import coil3.request.error
-import coil3.request.placeholder
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.kova700.bookchat.core.data.channel.external.model.ChannelDefaultImageType
 import com.kova700.bookchat.core.data.user.external.model.UserDefaultProfileType
 import com.kova700.bookchat.core.design_system.R
@@ -25,10 +24,12 @@ fun ImageView.loadUrl(
 	if (tag == key) return
 	tag = key
 
-	load(url) {
-		placeholder(placeholderResId)
-		error(errorResId)
-	}
+	Glide.with(context)
+		.load(url)
+		.placeholder(placeholderResId)
+		.error(errorResId)
+		.transition(DrawableTransitionOptions.withCrossFade())
+		.into(this)
 }
 
 fun ImageView.loadBitmap(
@@ -41,10 +42,12 @@ fun ImageView.loadBitmap(
 	if (tag == key) return
 	tag = key
 
-	load(bitmap) {
-		placeholder(placeholderResId)
-		error(errorResId)
-	}
+	Glide.with(context)
+		.load(bitmap)
+		.placeholder(placeholderResId)
+		.error(errorResId)
+		.transition(DrawableTransitionOptions.withCrossFade())
+		.into(this)
 }
 
 fun ImageView.loadByteArray(
@@ -57,10 +60,12 @@ fun ImageView.loadByteArray(
 	if (tag == key) return
 	tag = key
 
-	load(byteArray) {
-		placeholder(placeholderResId)
-		error(errorResId)
-	}
+	Glide.with(context)
+		.load(byteArray)
+		.placeholder(placeholderResId)
+		.error(errorResId)
+		.transition(DrawableTransitionOptions.withCrossFade())
+		.into(this)
 }
 
 fun ImageView.loadResId(
@@ -72,10 +77,12 @@ fun ImageView.loadResId(
 	if (tag == key) return
 	tag = key
 
-	load(resId) {
-		placeholder(placeholderResId)
-		error(errorResId)
-	}
+	Glide.with(context)
+		.load(resId)
+		.placeholder(placeholderResId)
+		.error(errorResId)
+		.transition(DrawableTransitionOptions.withCrossFade())
+		.into(this)
 }
 
 fun ImageView.loadUserProfile(

--- a/BookChat/feature/agony/src/main/kotlin/com/kova700/bookchat/feature/agony/agonyrecord/AgonyRecordActivity.kt
+++ b/BookChat/feature/agony/src/main/kotlin/com/kova700/bookchat/feature/agony/agonyrecord/AgonyRecordActivity.kt
@@ -1,9 +1,11 @@
 package com.kova700.bookchat.feature.agony.agonyrecord
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -33,6 +35,10 @@ class AgonyRecordActivity : AppCompatActivity() {
 	lateinit var agonyRecordSwipeHelper: AgonyRecordSwipeHelper
 
 	private val agonyRecordViewModel: AgonyRecordViewModel by viewModels()
+
+	private val imm by lazy {
+		getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -148,6 +154,13 @@ class AgonyRecordActivity : AppCompatActivity() {
 		onBackPressedDispatcher.addCallback { agonyRecordViewModel.onBackBtnClick() }
 	}
 
+	private fun closeKeyboard() {
+		imm.hideSoftInputFromWindow(
+			currentFocus?.windowToken,
+			InputMethodManager.HIDE_NOT_ALWAYS
+		)
+	}
+
 	private fun handleEvent(event: AgonyRecordEvent) {
 		when (event) {
 			is AgonyRecordEvent.MoveToBack -> finish()
@@ -158,6 +171,7 @@ class AgonyRecordActivity : AppCompatActivity() {
 
 			is AgonyRecordEvent.ShowEditCancelWarning -> showEditCancelWarning()
 			is AgonyRecordEvent.ShowSnackBar -> binding.root.showSnackBar(textId = event.stringId)
+			AgonyRecordEvent.CloseKeyboard -> closeKeyboard()
 		}
 	}
 

--- a/BookChat/feature/agony/src/main/kotlin/com/kova700/bookchat/feature/agony/agonyrecord/AgonyRecordContract.kt
+++ b/BookChat/feature/agony/src/main/kotlin/com/kova700/bookchat/feature/agony/agonyrecord/AgonyRecordContract.kt
@@ -46,6 +46,7 @@ data class AgonyRecordUiState(
 
 sealed class AgonyRecordEvent {
 	data object MoveToBack : AgonyRecordEvent()
+	data object CloseKeyboard : AgonyRecordEvent()
 	data class MoveToAgonyTitleEdit(
 		val agonyId: Long,
 		val bookshelfItemId: Long,

--- a/BookChat/feature/agony/src/main/kotlin/com/kova700/bookchat/feature/agony/agonyrecord/AgonyRecordViewModel.kt
+++ b/BookChat/feature/agony/src/main/kotlin/com/kova700/bookchat/feature/agony/agonyrecord/AgonyRecordViewModel.kt
@@ -108,6 +108,7 @@ class AgonyRecordViewModel @Inject constructor(
 		}.onSuccess {
 			updateFirstItemState(ItemState.Success())
 			updateState { copy(uiState = UiState.SUCCESS) }
+			startEvent(AgonyRecordEvent.CloseKeyboard)
 		}.onFailure {
 			startEvent(AgonyRecordEvent.ShowSnackBar(R.string.agony_record_make_fail))
 			updateFirstItemState(
@@ -136,6 +137,7 @@ class AgonyRecordViewModel @Inject constructor(
 		}.onSuccess {
 			_itemState.update { _itemState.value + (recordItem.recordId to ItemState.Success()) }
 			updateState { copy(uiState = UiState.SUCCESS) }
+			startEvent(AgonyRecordEvent.CloseKeyboard)
 		}.onFailure { startEvent(AgonyRecordEvent.ShowSnackBar(R.string.agony_record_revise_fail)) }
 	}
 

--- a/BookChat/feature/channel-list/src/main/res/layout/item_channel_list_data.xml
+++ b/BookChat/feature/channel-list/src/main/res/layout/item_channel_list_data.xml
@@ -106,7 +106,7 @@
             android:id="@+id/channel_last_chat_tv"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="60dp"
+            android:layout_marginEnd="10dp"
             android:elegantTextHeight="true"
             android:ellipsize="end"
             android:fontFamily="@font/notosanskr_regular"

--- a/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelActivity.kt
+++ b/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelActivity.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.view.ViewPropertyAnimator
 import android.view.animation.OvershootInterpolator
@@ -44,7 +43,6 @@ import com.kova700.bookchat.feature.channel.drawer.dialog.ExplodedChannelNoticeD
 import com.kova700.bookchat.feature.channel.drawer.mapper.toUser
 import com.kova700.bookchat.feature.channel.drawer.model.ChannelDrawerItem
 import com.kova700.bookchat.feature.channel.userprofile.UserProfileActivity
-import com.kova700.bookchat.util.Constants.TAG
 import com.kova700.bookchat.util.image.image.loadUserProfile
 import com.kova700.bookchat.util.recyclerview.isOnHigherPosition
 import com.kova700.bookchat.util.recyclerview.isOnListBottom
@@ -557,7 +555,6 @@ class ChannelActivity : AppCompatActivity() {
 					return@addCallback
 				}
 			}
-			Log.d(TAG, "ChannelActivity: setBackPressedDispatcher() - called")
 			channelViewModel.onClickBackBtn()
 		}
 	}

--- a/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelViewModel.kt
+++ b/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelViewModel.kt
@@ -442,21 +442,12 @@ class ChannelViewModel @Inject constructor(
 		scrollToBottom()
 	}
 
-	private var testCount = 0
 	fun onClickCaptureBtn() {
-//		if (uiState.value.channel.isAvailable.not()
-//			|| uiState.value.chats.isEmpty()
-//		) return
-//		updateState { copy(isCaptureMode = true) }
-//		_captureIds.update { null }
-
-		List(100) { "${testCount}번째 테스트 item $it" }.forEach { message ->
-			chatClient.sendMessage(
-				channelId = channelId,
-				message = message,
-			)
-		}
-		testCount++
+		if (uiState.value.channel.isAvailable.not()
+			|| uiState.value.chats.isEmpty()
+		) return
+		updateState { copy(isCaptureMode = true) }
+		_captureIds.update { null }
 	}
 
 	fun onClickMenuBtn() {

--- a/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelViewModel.kt
+++ b/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelViewModel.kt
@@ -1,6 +1,5 @@
 package com.kova700.bookchat.feature.channel.chatting
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -25,7 +24,6 @@ import com.kova700.bookchat.feature.channel.chatting.ChannelUiState.UiState
 import com.kova700.bookchat.feature.channel.chatting.mapper.toChatItems
 import com.kova700.bookchat.feature.channel.chatting.model.ChatItem
 import com.kova700.bookchat.feature.channel.drawer.mapper.toDrawerItems
-import com.kova700.bookchat.util.Constants.TAG
 import com.kova700.core.domain.usecase.channel.GetClientChannelFlowUseCase
 import com.kova700.core.domain.usecase.channel.GetClientChannelInfoUseCase
 import com.kova700.core.domain.usecase.channel.GetClientChannelUseCase
@@ -48,6 +46,7 @@ import kotlin.math.abs
 // TODO : [FixWaiting] ChannelMember 리스트가 텅빈채로 보이는 현상이 있음
 // TODO : [FixWaiting] 채팅방 입장 헀는데 인원수 1명으로 그대로인 현상이 있음
 // TODO : [FixWaiting] 채팅방 퇴장 했는데, 채팅방 인원 수 갱신안되는 현상이 있음
+// TODO : [FixWaiting] 오랫동안 채팅 화면 켜둔채로 화면 잠금 걸어두고 돌아오면 재연결 안되는 현상이 있음
 
 @HiltViewModel
 class ChannelViewModel @Inject constructor(
@@ -84,7 +83,6 @@ class ChannelViewModel @Inject constructor(
 	}
 
 	private fun initUiState() = viewModelScope.launch {
-		Log.d(TAG, "ChannelViewModel: initUiState() - channelId: $channelId")
 		if (isBookChatAvailable().not()) return@launch
 		val originalChannel = getClientChannelUseCase(channelId) ?: return@launch
 		val shouldLastReadChatScroll = originalChannel.isExistNewChat
@@ -109,7 +107,6 @@ class ChannelViewModel @Inject constructor(
 	}
 
 	private suspend fun getOfflineNewestChats() {
-		Log.d(TAG, "ChannelViewModel: getOfflineNewestChats(channelId : $channelId) - called")
 		chatRepository.getOfflineNewestChats(channelId)
 	}
 
@@ -194,7 +191,6 @@ class ChannelViewModel @Inject constructor(
 	private fun observeChannelSubscriptionState() = viewModelScope.launch {
 		var isFirstFailed = true
 		chatClient.getChannelSubscriptionStateFlow(channelId).collect { state ->
-			Log.d(TAG, "ChannelViewModel: observeChannelSubscriptionState() - state : $state")
 			when (state) {
 				SubscriptionState.SUBSCRIBING -> Unit
 				SubscriptionState.UNSUBSCRIBED -> subscribeChannelIfNeeded()
@@ -220,7 +216,6 @@ class ChannelViewModel @Inject constructor(
 	//TODO : [Version 2] 현재 보고 있는 채팅방에 한해서만 동기화 요청되게 사용하고 있지만,
 	// 			추후 EventHistory를 통해 모든 채팅방에 대한 동기화 요청으로 수정하고 ChatClient로 이전
 	private fun syncChannelIfNeeded() {
-		Log.d(TAG, "ChannelViewModel: syncChannelsIfNeeded() - called")
 		runCatching { channelSyncManger.sync(listOf(channelId)) }
 			.onFailure { ChannelEvent.ShowSnackBar(R.string.channel_info_sync_fail) }
 	}
@@ -258,7 +253,6 @@ class ChannelViewModel @Inject constructor(
 		if (networkManager.isNetworkAvailable().not()
 			|| uiState.value.channel.isAvailable.not()
 		) return@launch
-		Log.d(TAG, "ChannelViewModel: getInitChats(channelId : $channelId) - called")
 		val newestChats = getNewestChats().await() ?: emptyList()
 		val originalLastReadChatId = uiState.value.originalLastReadChatId ?: return@launch
 		val shouldLastReadChatScroll =
@@ -277,9 +271,7 @@ class ChannelViewModel @Inject constructor(
 	}
 
 	private fun getNewestChats(shouldBottomScroll: Boolean = false) = viewModelScope.async {
-		Log.d(TAG, "ChannelViewModel: getNewestChats() - called")
 		if (uiState.value.isInitLoading) return@async null
-		Log.d(TAG, "ChannelViewModel: getNewestChats() - 실제 API 호출")
 		updateState { copy(uiState = UiState.INIT_LOADING) }
 		runCatching { chatRepository.getNewestChats(channelId) }
 			.onSuccess {
@@ -298,7 +290,6 @@ class ChannelViewModel @Inject constructor(
 
 	private fun getNewerChats() = viewModelScope.launch {
 		if (uiState.value.isPossibleToLoadNewerChat.not()) return@launch
-		Log.d(TAG, "ChannelViewModel: getNewerChats() - called")
 		updateState { copy(newerChatsLoadState = LoadState.LOADING) }
 		runCatching { chatRepository.getNewerChats(channelId) }
 			.onSuccess { updateState { copy(newerChatsLoadState = LoadState.SUCCESS) } }
@@ -310,7 +301,6 @@ class ChannelViewModel @Inject constructor(
 
 	private fun getOlderChats() = viewModelScope.launch {
 		if (uiState.value.isPossibleToLoadOlderChat.not()) return@launch
-		Log.d(TAG, "ChannelViewModel: getOlderChats() - called")
 		updateState { copy(olderChatsLoadState = LoadState.LOADING) }
 		runCatching { chatRepository.getOlderChats(channelId) }
 			.onSuccess { updateState { copy(olderChatsLoadState = LoadState.SUCCESS) } }

--- a/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelViewModel.kt
+++ b/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelViewModel.kt
@@ -49,9 +49,6 @@ import kotlin.math.abs
 // TODO : [FixWaiting] 채팅방 입장 헀는데 인원수 1명으로 그대로인 현상이 있음
 // TODO : [FixWaiting] 채팅방 퇴장 했는데, 채팅방 인원 수 갱신안되는 현상이 있음
 
-// TODO : [FixWaiting] 채팅 전송 후, 하나는 대기 상태지만 같은 내용의 채팅이 완료상태로 중복 생성되는 현상이 있음
-//        아마도 소켓 통해서 보낸 메세지를 FCM으로 받아서 중복 생성되는 것 같음
-
 @HiltViewModel
 class ChannelViewModel @Inject constructor(
 	private val savedStateHandle: SavedStateHandle,

--- a/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelViewModel.kt
+++ b/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelViewModel.kt
@@ -49,6 +49,9 @@ import kotlin.math.abs
 // TODO : [FixWaiting] 채팅방 입장 헀는데 인원수 1명으로 그대로인 현상이 있음
 // TODO : [FixWaiting] 채팅방 퇴장 했는데, 채팅방 인원 수 갱신안되는 현상이 있음
 
+// TODO : [FixWaiting] 채팅 전송 후, 하나는 대기 상태지만 같은 내용의 채팅이 완료상태로 중복 생성되는 현상이 있음
+//        아마도 소켓 통해서 보낸 메세지를 FCM으로 받아서 중복 생성되는 것 같음
+
 @HiltViewModel
 class ChannelViewModel @Inject constructor(
 	private val savedStateHandle: SavedStateHandle,

--- a/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelViewModel.kt
+++ b/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/ChannelViewModel.kt
@@ -33,6 +33,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -47,6 +48,7 @@ import kotlin.math.abs
 // TODO : [FixWaiting] 채팅방 입장 헀는데 인원수 1명으로 그대로인 현상이 있음
 // TODO : [FixWaiting] 채팅방 퇴장 했는데, 채팅방 인원 수 갱신안되는 현상이 있음
 // TODO : [FixWaiting] 오랫동안 채팅 화면 켜둔채로 화면 잠금 걸어두고 돌아오면 재연결 안되는 현상이 있음
+// TODO : [FixWaiting] 코드 난독화 추가
 
 @HiltViewModel
 class ChannelViewModel @Inject constructor(
@@ -68,7 +70,7 @@ class ChannelViewModel @Inject constructor(
 	private val channelId = savedStateHandle.get<Long>(EXTRA_CHANNEL_ID)!!
 
 	private val _eventFlow = MutableSharedFlow<ChannelEvent>()
-	val eventFlow get() = _eventFlow
+	val eventFlow = _eventFlow.asSharedFlow()
 
 	private val _uiState = MutableStateFlow<ChannelUiState>(ChannelUiState.DEFAULT)
 	val uiState = _uiState.asStateFlow()
@@ -583,7 +585,7 @@ class ChannelViewModel @Inject constructor(
 	}
 
 	private fun startEvent(event: ChannelEvent) = viewModelScope.launch {
-		eventFlow.emit(event)
+		_eventFlow.emit(event)
 	}
 
 	private inline fun updateState(block: ChannelUiState.() -> ChannelUiState) {

--- a/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/adapter/ChatItemViewHolder.kt
+++ b/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/adapter/ChatItemViewHolder.kt
@@ -5,8 +5,8 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
 import com.kova700.bookchat.core.data.chat.external.model.ChatState
 import com.kova700.bookchat.core.design_system.R
-import com.kova700.bookchat.feature.channel.chatting.model.ChatItem
 import com.kova700.bookchat.feature.channel.chatting.capture.setCaptureViewState
+import com.kova700.bookchat.feature.channel.chatting.model.ChatItem
 import com.kova700.bookchat.feature.channel.databinding.ItemChattingDateBinding
 import com.kova700.bookchat.feature.channel.databinding.ItemChattingLastReadNoticeBinding
 import com.kova700.bookchat.feature.channel.databinding.ItemChattingMineBinding
@@ -46,11 +46,14 @@ class MyChatViewHolder(
 			failedChatDeleteBtn.setOnClickListener {
 				onClickFailedChatDeleteBtn?.invoke(absoluteAdapterPosition)
 			}
+			moveToWholeTextBtn.setOnClickListener {
+				onClickMoveToWholeText?.invoke(absoluteAdapterPosition)
+			}
 			root.setOnClickListener {
 				onSelectCaptureChat?.invoke(absoluteAdapterPosition)
 			}
-			moveToWholeTextBtn.setOnClickListener {
-				onClickMoveToWholeText?.invoke(absoluteAdapterPosition)
+			chattingLayout.setOnClickListener {
+				onSelectCaptureChat?.invoke(absoluteAdapterPosition)
 			}
 			chattingLayout.setOnLongClickListener {
 				onLongClickChatItem?.invoke(absoluteAdapterPosition)
@@ -123,11 +126,14 @@ class AnotherUserChatViewHolder(
 			userProfileIv.setOnClickListener {
 				onClickUserProfile?.invoke(absoluteAdapterPosition)
 			}
+			moveToWholeTextBtn.setOnClickListener {
+				onClickMoveToWholeText?.invoke(absoluteAdapterPosition)
+			}
 			root.setOnClickListener {
 				onSelectCaptureChat?.invoke(absoluteAdapterPosition)
 			}
-			moveToWholeTextBtn.setOnClickListener {
-				onClickMoveToWholeText?.invoke(absoluteAdapterPosition)
+			chattingLayout.setOnClickListener {
+				onSelectCaptureChat?.invoke(absoluteAdapterPosition)
 			}
 			chattingLayout.setOnLongClickListener {
 				onLongClickChatItem?.invoke(absoluteAdapterPosition)

--- a/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/adapter/ChatItemViewHolder.kt
+++ b/BookChat/feature/channel/src/main/kotlin/com/kova700/bookchat/feature/channel/chatting/adapter/ChatItemViewHolder.kt
@@ -13,7 +13,7 @@ import com.kova700.bookchat.feature.channel.databinding.ItemChattingMineBinding
 import com.kova700.bookchat.feature.channel.databinding.ItemChattingNoticeBinding
 import com.kova700.bookchat.feature.channel.databinding.ItemChattingOtherBinding
 import com.kova700.bookchat.util.date.toFormattedTimeText
-import com.kova700.bookchat.util.emoji.isSingleTextOrEmoji
+import com.kova700.bookchat.util.emoji.isSingleEmoji
 import com.kova700.bookchat.util.image.image.loadUserProfile
 
 sealed class ChatItemViewHolder(
@@ -105,8 +105,8 @@ class MyChatViewHolder(
 	private fun setMessageTextState(message: String) {
 		with(binding) {
 			chattingLayout.background =
-				if (message.isSingleTextOrEmoji()) null else root.context.getDrawable(R.drawable.chat_bubble_blue)
-			chatTv.textSize = if (message.isSingleTextOrEmoji()) 70f else 12f
+				if (message.isSingleEmoji()) null else root.context.getDrawable(R.drawable.chat_bubble_blue)
+			chatTv.textSize = if (message.isSingleEmoji()) 70f else 12f
 			chatTv.text =
 				if (message.length > MAX_MESSAGE_LENGTH) message.substring(0, MAX_MESSAGE_LENGTH) + "..."
 				else message
@@ -184,8 +184,8 @@ class AnotherUserChatViewHolder(
 	private fun setMessageTextState(message: String) {
 		with(binding) {
 			chattingLayout.background =
-				if (message.isSingleTextOrEmoji()) null else root.context.getDrawable(R.drawable.chat_bubble_gray)
-			chatTv.textSize = if (message.isSingleTextOrEmoji()) 70f else 12f
+				if (message.isSingleEmoji()) null else root.context.getDrawable(R.drawable.chat_bubble_gray)
+			chatTv.textSize = if (message.isSingleEmoji()) 70f else 12f
 			chatTv.text =
 				if (message.length > MAX_MESSAGE_LENGTH) message.substring(0, MAX_MESSAGE_LENGTH) + "..."
 				else message

--- a/BookChat/feature/create-channel/src/main/kotlin/com/kova700/bookchat/feature/createchannel/MakeChannelViewModel.kt
+++ b/BookChat/feature/create-channel/src/main/kotlin/com/kova700/bookchat/feature/createchannel/MakeChannelViewModel.kt
@@ -93,6 +93,7 @@ class MakeChannelViewModel @Inject constructor(
 	}
 
 	fun onClickTextClearBtn() {
+		if (uiState.value.isLoading) return
 		updateState { copy(channelTitle = "") }
 	}
 
@@ -105,10 +106,12 @@ class MakeChannelViewModel @Inject constructor(
 	}
 
 	fun onClickDeleteSelectedBookBtn() {
+		if (uiState.value.isLoading) return
 		updateState { copy(selectedBook = null) }
 	}
 
 	fun onClickCameraBtn() {
+		if (uiState.value.isLoading) return
 		startEvent(MakeChannelEvent.ShowChannelImageSelectDialog)
 	}
 

--- a/BookChat/feature/home/src/main/res/layout/item_home_channel.xml
+++ b/BookChat/feature/home/src/main/res/layout/item_home_channel.xml
@@ -93,7 +93,7 @@
         android:id="@+id/last_chat_content_tv"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="60dp"
+        android:layout_marginEnd="10dp"
         android:elegantTextHeight="true"
         android:ellipsize="end"
         android:fontFamily="@font/notosanskr_regular"

--- a/BookChat/feature/image-crop/src/main/kotlin/com/kova700/bookchat/feature/imagecrop/ImageCropActivity.kt
+++ b/BookChat/feature/image-crop/src/main/kotlin/com/kova700/bookchat/feature/imagecrop/ImageCropActivity.kt
@@ -15,12 +15,6 @@ import com.kova700.bookchat.feature.imagecrop.model.ImageCropAspectRatio
 import com.kova700.bookchat.util.image.image.saveImageToCacheAndGetUri
 import kotlinx.coroutines.launch
 
-//TODO: [FixWaiting] 이미지 선택하고 확인 누르고 채팅방 생성하면 실패하는 이슈 있음
-//  잘라서 전달하면 성공하고 있음
-// 문제되는 사진
-// END POST (1272336-byte body) (크롭해서 전달하면 성공하는데 차이를 모르겠음)
-// 문제 안되는 사진
-// END POST (710175-byte body)
 class ImageCropActivity : AppCompatActivity() {
 
 	private lateinit var binding: ActivityImageCropBinding
@@ -50,13 +44,15 @@ class ImageCropActivity : AppCompatActivity() {
 
 	private fun setViewState(uiState: ImageCropUiState) {
 		setCropImageViewState(uiState)
-		binding.defaultStateGroup.visibility =
-			if (uiState.isDefault) View.VISIBLE else View.GONE
-		binding.imageCropStateGroup.visibility =
-			if (uiState.isImageCropping) View.VISIBLE else View.GONE
-		binding.imageCropTitle.text =
-			if (uiState.isImageCropping) getString(R.string.image_crop_title)
-			else getString(R.string.select_image)
+		with(binding) {
+			defaultStateGroup.visibility =
+				if (uiState.isDefault) View.VISIBLE else View.GONE
+			imageCropStateGroup.visibility =
+				if (uiState.isImageCropping) View.VISIBLE else View.GONE
+			imageCropTitle.text =
+				if (uiState.isImageCropping) getString(R.string.image_crop_title)
+				else getString(R.string.select_image)
+		}
 	}
 
 	private fun setCropImageViewState(uiState: ImageCropUiState) {

--- a/BookChat/feature/image-crop/src/main/kotlin/com/kova700/bookchat/feature/imagecrop/ImageCropActivity.kt
+++ b/BookChat/feature/image-crop/src/main/kotlin/com/kova700/bookchat/feature/imagecrop/ImageCropActivity.kt
@@ -15,6 +15,12 @@ import com.kova700.bookchat.feature.imagecrop.model.ImageCropAspectRatio
 import com.kova700.bookchat.util.image.image.saveImageToCacheAndGetUri
 import kotlinx.coroutines.launch
 
+//TODO: [FixWaiting] 이미지 선택하고 확인 누르고 채팅방 생성하면 실패하는 이슈 있음
+//  잘라서 전달하면 성공하고 있음
+// 문제되는 사진
+// END POST (1272336-byte body) (크롭해서 전달하면 성공하는데 차이를 모르겠음)
+// 문제 안되는 사진
+// END POST (710175-byte body)
 class ImageCropActivity : AppCompatActivity() {
 
 	private lateinit var binding: ActivityImageCropBinding

--- a/BookChat/feature/image-crop/src/main/kotlin/com/kova700/bookchat/feature/imagecrop/ImageCropContract.kt
+++ b/BookChat/feature/image-crop/src/main/kotlin/com/kova700/bookchat/feature/imagecrop/ImageCropContract.kt
@@ -2,7 +2,6 @@ package com.kova700.bookchat.feature.imagecrop
 
 import android.graphics.Bitmap
 import android.net.Uri
-import com.kova700.bookchat.core.navigation.ImageCropNavigator
 import com.kova700.bookchat.core.navigation.ImageCropNavigator.ImageCropPurpose
 import com.kova700.bookchat.feature.imagecrop.model.ImageCropAspectRatio
 

--- a/BookChat/feature/image-crop/src/main/kotlin/com/kova700/bookchat/feature/imagecrop/ImageCropViewModel.kt
+++ b/BookChat/feature/image-crop/src/main/kotlin/com/kova700/bookchat/feature/imagecrop/ImageCropViewModel.kt
@@ -136,7 +136,7 @@ class ImageCropViewModel @Inject constructor(
 		}
 	}
 
-	fun startEvent(event: ImageCropUiEvent) = viewModelScope.launch {
+	private fun startEvent(event: ImageCropUiEvent) = viewModelScope.launch {
 		_eventFlow.emit(event)
 	}
 

--- a/BookChat/feature/mypage/src/main/kotlin/com/kova700/bookchat/feature/mypage/setting/accountsetting/AccountSettingActivity.kt
+++ b/BookChat/feature/mypage/src/main/kotlin/com/kova700/bookchat/feature/mypage/setting/accountsetting/AccountSettingActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View.GONE
 import android.view.View.VISIBLE
+import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -31,6 +32,7 @@ class AccountSettingActivity : AppCompatActivity() {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 		binding = ActivityAccountSettingBinding.inflate(layoutInflater)
+		setBackPressedDispatcher()
 		setContentView(binding.root)
 		initViewState()
 		observeUiState()
@@ -51,7 +53,7 @@ class AccountSettingActivity : AppCompatActivity() {
 
 	private fun initViewState() {
 		with(binding) {
-			backBtn.setOnClickListener { finish() }
+			backBtn.setOnClickListener { accountSettingViewModel.onClickBackBtn() }
 			logoutBtn.setOnClickListener { accountSettingViewModel.onClickLogoutBtn() }
 			withdrawBtn.setOnClickListener { accountSettingViewModel.onClickWithdrawBtn() }
 		}
@@ -95,6 +97,13 @@ class AccountSettingActivity : AppCompatActivity() {
 			AccountSettingUiEvent.ShowWithdrawWarningDialog -> showWithdrawWarningDialog()
 			AccountSettingUiEvent.StartOAuthLogout -> startOAuthLogout()
 			AccountSettingUiEvent.StartOAuthWithdraw -> startOAuthWithdraw()
+			AccountSettingUiEvent.MoveToBack -> finish()
+		}
+	}
+
+	private fun setBackPressedDispatcher() {
+		onBackPressedDispatcher.addCallback {
+			accountSettingViewModel.onClickBackBtn()
 		}
 	}
 

--- a/BookChat/feature/mypage/src/main/kotlin/com/kova700/bookchat/feature/mypage/setting/accountsetting/AccountSettingContract.kt
+++ b/BookChat/feature/mypage/src/main/kotlin/com/kova700/bookchat/feature/mypage/setting/accountsetting/AccountSettingContract.kt
@@ -20,6 +20,7 @@ data class AccountSettingUiState(
 }
 
 sealed class AccountSettingUiEvent {
+	data object MoveToBack : AccountSettingUiEvent()
 	data object MoveToLoginPage : AccountSettingUiEvent()
 	data object ShowWithdrawWarningDialog : AccountSettingUiEvent()
 	data object StartOAuthLogout : AccountSettingUiEvent()

--- a/BookChat/feature/mypage/src/main/kotlin/com/kova700/bookchat/feature/mypage/setting/accountsetting/AccountSettingViewModel.kt
+++ b/BookChat/feature/mypage/src/main/kotlin/com/kova700/bookchat/feature/mypage/setting/accountsetting/AccountSettingViewModel.kt
@@ -67,6 +67,11 @@ class AccountSettingViewModel @Inject constructor(
 		startEvent(AccountSettingUiEvent.ShowWithdrawWarningDialog)
 	}
 
+	fun onClickBackBtn() {
+		if (_uiState.value.isLoading) return
+		startEvent(AccountSettingUiEvent.MoveToBack)
+	}
+
 	private fun startEvent(event: AccountSettingUiEvent) = viewModelScope.launch {
 		_eventFlow.emit(event)
 	}

--- a/BookChat/gradle/libs.versions.toml
+++ b/BookChat/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ kakaoSDK = "2.11.0"
 credentials = "1.2.2"
 googleIdentityGoogleId = "1.1.1"
 
-glide = "4.16.0"
+coil = "3.0.1"
 
 room = "2.6.1"
 datastorePreferences = "1.1.1"
@@ -108,8 +108,8 @@ hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 
 ## Image loader
-glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
-glide-compiler = { group = "com.github.bumptech.glide", name = "compiler", version.ref = "glide" }
+coil = { group = "io.coil-kt.coil3", name = "coil", version.ref = "coil" }
+coil-network = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 
 ## Network
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
@@ -235,6 +235,10 @@ room = [
     "androidx-room-runtime",
     "androidx-room-ktx",
     "androidx-room-paging"
+]
+coil = [
+    "coil",
+    "coil-network"
 ]
 workmanager = [
     "androidx-work-runtime-ktx",

--- a/BookChat/gradle/libs.versions.toml
+++ b/BookChat/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ kakaoSDK = "2.11.0"
 credentials = "1.2.2"
 googleIdentityGoogleId = "1.1.1"
 
-coil = "3.0.1"
+glide = "4.16.0"
 
 room = "2.6.1"
 datastorePreferences = "1.1.1"
@@ -108,8 +108,8 @@ hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 
 ## Image loader
-coil = { group = "io.coil-kt.coil3", name = "coil", version.ref = "coil" }
-coil-network = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
+glide-compiler = { group = "com.github.bumptech.glide", name = "compiler", version.ref = "glide" }
 
 ## Network
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
@@ -235,10 +235,6 @@ room = [
     "androidx-room-runtime",
     "androidx-room-ktx",
     "androidx-room-paging"
-]
-coil = [
-    "coil",
-    "coil-network"
 ]
 workmanager = [
     "androidx-work-runtime-ktx",


### PR DESCRIPTION
### 1. **버그 수정**  
- 고민 기록 수정 완료 시 키보드가 내려가지 않는 문제 해결.  
- 채널 목록 속 마지막 채팅 좌우 노출 범위를 더 넓게 수정.  
- 로그아웃 및 회원 탈퇴 중 액티비티 종료 방지 코드 추가.  
- 구독이 안 된 상태에서 소켓만 연결되었을 때, 연결 완료 UI가 잘못 노출되는 문제 수정.  
- 이미지 최대 용량 설정 및 압축 로직 개선, 이미지 압축 시 무한 로딩 이슈 해결.  
- 캡처 모드에서 채팅 말풍선을 클릭할 경우 캡처가 선택되지 않는 문제 해결.  
- 이미지 크롭 후 이미지 용량이 클 경우 재압축 로직 추가.  

---

### 2. **리팩토링**  
- **EmojiUtil**의 이모지 판별 방식을 정규식 기반으로 수정.  
- **FCM**에서 SenderId를 함께 전달받아 클라이언트인 경우 `getChat`, `getChannel` API 호출을 방지하도록 코드 개선.  

---

### 3. **기타 변경 사항**  
- **app:build.gradle**에서 불필요한 의존성 제거.  
- 불필요한 테스트 코드 및 TODO 제거.  
- 함수 반환 스타일 수정 (`RenewFcmTokenWorker`).  
